### PR TITLE
Add Jenkins plugin updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ See these repositories:
 * https://github.com/Praqma/job-dsl-collection
 * https://github.com/Praqma/jobdsl-helpers
 
+### Jenkins Plugin Updater
+
+Jenkinsfile and bash script that will enable Jenkins to automatically update plugins that have more recent versions. See [Readme.MD](./jenkins-autoupdate-plugins/Readme.MD) for details. 
+
+Have faith in Continuous Integration go for the latest plugin versions...
+
 ### Transform and Run
 
 A script that can transform another script, before executing it. Usage can be scripts that can't take variables, or are used as inputs to other scripts.
@@ -77,7 +83,6 @@ Simple little groovy script to check DNS lookup, TCP connection and ping and cur
 Check firewall rules, from node to node using Jenkins build slave. You can't easily do this with monitoring systems.
 
 Read more on use-case in the [sub directory readme in powerping](powerping/README.md)
-
 
 ### File pattern scanner
 
@@ -112,7 +117,6 @@ Within the folder of each util, there should be a readme explaining how to use, 
 * Please make sure scripts are anonymized - no customer, or specific user details.
 
 Folders might later be categorized in further levels.
-
 
 # Contribution criterias
 

--- a/jenkins-autoupdate-plugins/Jenkinsfile
+++ b/jenkins-autoupdate-plugins/Jenkinsfile
@@ -1,0 +1,37 @@
+pipeline {
+    agent any
+
+    stages {
+        stage('Install plugin updates') {
+            steps {
+                sh label: 'Get jenkins-cli.jar', script:
+                '''
+                  #!/usr/bin/bash
+                  set +x
+                  wget --no-verbose ${JENKINS_URL}jnlpJars/jenkins-cli.jar
+                '''
+                withCredentials(
+                  [usernamePassword(
+                    credentialsId: 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA',
+                    passwordVariable: 'PASSWORD',
+                    usernameVariable: 'USERNAME'
+                  )])
+                  {
+                    sh label: 'Check for updates and install', script:
+                    '''
+                      bash ./jenkinsJobs/UpdatePlugins/UpdatePlugins.sh
+                    '''
+                  }
+                script {
+                    currentBuild.description = readFile './description.txt'
+                }
+                archiveArtifacts artifacts: 'description.txt', followSymlinks: false
+            }
+        }
+    }
+    post {
+        always {
+            deleteDir()
+        }
+    }
+}

--- a/jenkins-autoupdate-plugins/Readme.MD
+++ b/jenkins-autoupdate-plugins/Readme.MD
@@ -1,0 +1,43 @@
+# Jenkins Pipeline to update Jenkins plugins
+
+This pipeline and script will install all updatable plugins.
+
+It can be a struggle to keep Jenkins plugin updated, and I have seen many installations running with plugins that has been outdated years ago, and the
+more versions you are behind the more reluctant you are to update.
+The cure is update when updates are available.
+
+It utilizes the [jenkins-cli](https://www.jenkins.io/doc/book/managing/cli/) `list-plugins` command to get the list
+of installed plugins, and utilizes that the version plugin's version number will be enclosed in parenthesis if there is an update version of the plugin.
+
+The output from `jenkins-cli list-plugins` is formatted like this example:
+
+```text
+ansible                            Ansible plugin                                  403.v8d0ca_dcb_b_502
+ant                                Ant Plugin                                      511.v0a_a_1a_334f41b_
+antisamy-markup-formatter          OWASP Markup Formatter Plugin                   (162.v0e6ec0fcfcf6)
+apache-httpcomponents-client-4-api Apache HttpComponents Client 4.x API Plugin     4.5.14-208.v438351942757
+...
+```
+
+in the example can be updated. An this pipeline *will* update to the new version.
+
+## Requirements  
+
+* Jenkins server configured to support [jenkins-cli](https://www.jenkins.io/doc/book/managing/cli/)
+* A user credential with permission to update plugins
+* The `Safe Restart Plugin`
+
+## Setup
+
+1. Configure a user with administrator permissions and create an api token for this user
+2. Download jenkins-cli-jar from your <http://yourJenkinsUrl/jnlpJars/jenkins-cli.jar>
+3. Verify jenkins responds to jenkins-cli by executing:
+
+    ```bash
+    java -jar jenkins-cli.jar -s <jenkins_url> -auth <theAdminUser>:<theAdminUsersAPIToken> list-plugins 
+    ```
+
+4. Create a Jenkins Secret type `username with password`, with the values from step 1. Note of it's ID value
+5. Edit Jenkinsfile and replace `AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA` with the ID value from step 4.
+6. Ensure you have functional, regular back of Jenkins
+7. Create the pipeline and make it run on.

--- a/jenkins-autoupdate-plugins/UpdatePlugins.sh
+++ b/jenkins-autoupdate-plugins/UpdatePlugins.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/bash
+
+set +x
+
+AUTH=$USERNAME:$PASSWORD
+MYCLICMDLINE="java -jar ./jenkins-cli.jar -s ${JENKINS_URL} -auth $AUTH"
+
+TOINSTALL=$(${MYCLICMDLINE} list-plugins | grep -E ')$' | awk '{print $1}' | tr '\n' ' ')
+
+if [ -z "$TOINSTALL" ]; then
+    echo "<b>No plugins to update.</b>" | tee ./description.txt
+else
+    echo "<b>Updating the following plugins:<br>" | tee ./description.txt
+    # shellcheck disable=SC2086
+    echo ${TOINSTALL} | tr -s ' ' | sed -e 's/[[:space:]]/<br>/g' | tee --append ./description.txt
+    echo '</b>' | tee --append ./description.txt
+    # shellcheck disable=SC2086
+    $MYCLICMDLINE install-plugin ${TOINSTALL}
+    $MYCLICMDLINE safe-restart -message "Plugins have been updated, must restart"
+fi

--- a/jenkins-autoupdate-plugins/UpdatePlugins.sh
+++ b/jenkins-autoupdate-plugins/UpdatePlugins.sh
@@ -15,6 +15,6 @@ else
     echo ${TOINSTALL} | tr -s ' ' | sed -e 's/[[:space:]]/<br>/g' | tee --append ./description.txt
     echo '</b>' | tee --append ./description.txt
     # shellcheck disable=SC2086
-    $MYCLICMDLINE install-plugin ${TOINSTALL}
-    $MYCLICMDLINE safe-restart -message "Plugins have been updated, must restart"
+    $MYCLICMDLINE install-plugin ${TOINSTALL} -restart
+    # $MYCLICMDLINE safe-restart -message "Plugins have been updated, must restart"
 fi


### PR DESCRIPTION
Jenkins Pipeline to update Jenkins plugins

This pipeline and script will install all updatable plugins.

It can be a struggle to keep Jenkins plugin updated, and I have seen many installations running with plugins that has been outdated years ago, and the
more versions you are behind the more reluctant you are to update.
The cure is update when updates are available.